### PR TITLE
Only display the downloadable PDF button if we are not in an app.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -381,7 +381,7 @@ Its two components will be available as the following global variables:
 + `iconHighResPrefix` – the prefix added to the name of the images used for high resolution devices
 + `iconFileExtension` – the extension of the image files used for the toolbar buttons
 + `shouldUseHighRes` – `true` if the images for high resolution should be used, `false` otherwise
-+ `hasDownloadablePdf` – `true` if the edition was set up with a downloadable PDF, `false` otherwise
++ `hasDownloadablePdfAndIsNotApp` – `true` if the edition was set up with a downloadable PDF and is not being used within an app on a device, `false` otherwise
 + `searchEnabled` – `true` if the edition was set up with search enabled, `false` otherwise
 + `editionListEnabled` – `true` if the edition was set up with the edition list (archive view) enabled and it is not being shown within an app, `false` otherwise
 + `orderFormEnabled` – `true` if the edition was set up with the order form enabled, `false` otherwise

--- a/toolbar/toolbar.js
+++ b/toolbar/toolbar.js
@@ -131,7 +131,7 @@ var createButtons = function() {
     if (yudu_toolbarSettings.sharing.emailEnabled || yudu_toolbarSettings.sharing.twitter || yudu_toolbarSettings.sharing.facebook) {
         createButton('share', toggleShareAction, highResIcons);
     }
-    if (yudu_toolbarSettings.hasDownloadablePdf && !yudu_toolbarSettings.isThisAnApp) {
+    if (yudu_toolbarSettings.hasDownloadablePdfAndIsNotApp) {
         createButton('downloadPdf', buttonOtherThanTogglableHit(this, yudu_toolbarFunctions.downloadPdfClicked), highResIcons);
     }
     if (yudu_toolbarSettings.searchEnabled && !yudu_commonSettings.isDesktop) {

--- a/toolbar/toolbar.js
+++ b/toolbar/toolbar.js
@@ -131,7 +131,7 @@ var createButtons = function() {
     if (yudu_toolbarSettings.sharing.emailEnabled || yudu_toolbarSettings.sharing.twitter || yudu_toolbarSettings.sharing.facebook) {
         createButton('share', toggleShareAction, highResIcons);
     }
-    if (yudu_toolbarSettings.hasDownloadablePdf) {
+    if (yudu_toolbarSettings.hasDownloadablePdf && !yudu_toolbarSettings.isThisAnApp) {
         createButton('downloadPdf', buttonOtherThanTogglableHit(this, yudu_toolbarFunctions.downloadPdfClicked), highResIcons);
     }
     if (yudu_toolbarSettings.searchEnabled && !yudu_commonSettings.isDesktop) {


### PR DESCRIPTION
When uploading a 'downloadable PDF' for an edition, we only want the button to appear when viewing the html edition if we are not within an app.

@alexanderherbertyudu @alexandergeeyudu 
