### PR TITLE
Converted http to https in link

### DIFF
--- a/info/desktop.html
+++ b/info/desktop.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:600,300' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:600,300' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" type="text/css" href="styles.css"/>
 </head>
 <body>

--- a/info/touch.html
+++ b/info/touch.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:600,300' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:600,300' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" type="text/css" href="styles.css"/>
 </head>
 <body>


### PR DESCRIPTION
Changed the http to https in this link to prevent the mixed content warning. I couldn't find any other instances.
eg https://content.yudu.com/web/7ixk/0A182m5/TTSIntEarlyYears2017/html/index.html?page=1084

@beth-hallowell-yudu 