### PR TITLE
Use HammerJS for some more events

### DIFF
--- a/info/desktop.html
+++ b/info/desktop.html
@@ -22,7 +22,7 @@
           </div>
             <p id="mouseText" class="yudu_localisable">info.mouseText</p>
 
-          <label class="noTouch"><input type="checkbox" name="noRepeatShow" id="noRepeatShow" class="noTouch yudu_localisable"> <span class="yudu_localisable">info.doNotShowAgain</span></label>
+          <label class="noTouch"><input type="checkbox" name="noRepeatShow" id="noRepeatShow"> <span class="yudu_localisable">info.doNotShowAgain</span></label>
           <button id="dismiss" class="yudu_localisable">info.close</button>
         </div>
     </div>

--- a/info/touch.html
+++ b/info/touch.html
@@ -18,7 +18,7 @@
       </div>
       <p class="yudu_localisable">info.touchText</p>
 
-      <label class="noTouch"><input type="checkbox" name="noRepeatShow" id="noRepeatShow" class="noTouch"> <span class="yudu_localisable">info.doNotShowAgain</span></label>
+      <label class="noTouch"><input type="checkbox" name="noRepeatShow" id="noRepeatShow"> <span class="yudu_localisable">info.doNotShowAgain</span></label>
       <button id="dismiss" class="yudu_localisable">info.close</button>
   </div>
 </div>

--- a/readme.md
+++ b/readme.md
@@ -275,6 +275,9 @@ Its two components will be available as the following global variables:
 + `orientation` – the orientation of the device: `landscape = 0`, `portrait = 1`
 + `hasIntroPage` – `true` if the edition was set up with an intro page, `false` otherwise
 + `createjs` – the "easel" library module
++ `hammerjs` – version 2 of the "HammerJS" library module
++ `hammerJSRecogniserPresets` - a hash of `Hammer.Recognizer` presets compatible with HammerJS2; currently contains:
+    + `TAP_ONLY` - a recogniser preset that will initialise a manager with only a `Hammer.Tap` `Recognizer` when used
 
 #### Common Functions
 
@@ -295,6 +298,9 @@ Its two components will be available as the following global variables:
 + `enableScrollingWithoutDocumentBouncing(element)` – use on touch devices only for scrollable elements to disable the bouncing of the entire document when scrolling to the beginning/end on iOS
 + `toolbarFinishedLoading` – call this after the toolbar submodule has finished loading
     + __NOT__ optional, as it sets `yudu_commonSettings.toolbarLoaded`, which is used by the core
++ `createHammerJSManagerWithRecognisers` - helper that takes an array of `Hammer.Recognizer`s and an element to create a `Manager` for, and returns the manager
++ `createHammerJSManagerWithOptions` - helper that takes an element to create a `Hammer.Manager` for, and an arbitrary object with HammerJS options, and returns the manager
++ `createHammerJSTapManager` - helper that takes an element to create a `Hammer.Manager` for, and returns a manager pre-initialised with only a `Hammer.Tap` `Recognizer`
 + `goToPage(pageNumber)` – call to jump to the page numbered `pageNumber`
 
 ### Contents

--- a/thumbnails/thumbnails.js
+++ b/thumbnails/thumbnails.js
@@ -52,6 +52,10 @@ var Thumbnails = function(settings) {
     //  Note ideal dimensions for a portrait page will have a ratio roughly equal to 1:sqrt(2)
     this.iconSize = settings.initialIconSizes;
 
+    // event handling
+    this.callbacks = {};
+    this.carouselManager = null;
+
     this.isVisible = false;
     //endregion
 
@@ -96,6 +100,8 @@ var Thumbnails = function(settings) {
         yudu_events.subscribe(yudu_events.ALL, yudu_events.THUMBNAILS.TOGGLE_THUMBNAILS, yudu_events.callback(self, function(event) { self.toggle(event.data.toggle, event.data.show); }));
         yudu_events.subscribe(yudu_events.ALL, yudu_events.THUMBNAILS.UPDATE_THUMBNAIL, yudu_events.callback(self, function(event) { self.updateThumbnail(event.data.pageNumber); }));
 
+        this.carouselManager = yudu_commonFunctions.createHammerJSTapManager(this.carouselContainerElement[0]);
+        this.carouselManager.on('tap', yudu_events.callback(self, this.handleInteraction));
     };
 
     /**
@@ -526,6 +532,26 @@ var Thumbnails = function(settings) {
     //endregion
 
     //region event handlers
+    /**
+     * Callback for taps on the thumbnails popup
+     * @param event {*} fired by HammerJS, DOM event nested in `event.srcEvent`
+     */
+    this.handleInteraction = function(event) {
+        var elementId = event.target.dataset.id;
+        var callback = this.callbacks[elementId];
+        typeof callback == 'function' && callback(event);
+    };
+
+    /**
+     * Registers an event handler for an element with the specified ID
+     * @param id {string} to identify the callback for the element being activated
+     *  should be unique within this thumbnails namespace
+     * @param callback {Function} to trigger when the associated element is activated
+     */
+    this.registerListener = function(id, callback) {
+        this.callbacks[id] = callback;
+    };
+
     /**
      * Event handler (HTML Reader) to respond to a page change event
      * @param event

--- a/thumbnails/thumbnails.js
+++ b/thumbnails/thumbnails.js
@@ -7,6 +7,13 @@
  *      (Deleting the components but not calls to their creation will still throw exceptions)
  *  It may suffice for basic use to modify the settings at the very bottom, applied to the Thumbnails object on construction
  *  For further changes, please see in-line comments. Remember to thoroughly test any changes made.
+ *
+ * Note on event handling:
+ *  This script currently makes use of multiple versions of HammerJS
+ *  HammerJS version 1 is available as a jQuery plugin via `$.hammer`
+ *  HammerJS version 2 is available indirectly via `yudu_commonSettings.hammerjs`
+ *  Various helpers for constructing HammerJS2 Manager objects are available from `yudu_commonFunctions`
+ *      Please see the documentation for more information
  */
 
 var Thumbnails = function(settings) {
@@ -100,6 +107,7 @@ var Thumbnails = function(settings) {
         yudu_events.subscribe(yudu_events.ALL, yudu_events.THUMBNAILS.TOGGLE_THUMBNAILS, yudu_events.callback(self, function(event) { self.toggle(event.data.toggle, event.data.show); }));
         yudu_events.subscribe(yudu_events.ALL, yudu_events.THUMBNAILS.UPDATE_THUMBNAIL, yudu_events.callback(self, function(event) { self.updateThumbnail(event.data.pageNumber); }));
 
+        // create a HammerJS2 Manager
         this.carouselManager = yudu_commonFunctions.createHammerJSTapManager(this.carouselContainerElement[0]);
         this.carouselManager.on('tap', yudu_events.callback(self, this.handleInteraction));
     };

--- a/thumbnails/thumbnails.js
+++ b/thumbnails/thumbnails.js
@@ -794,10 +794,12 @@ var CarouselSegmentedControl = function(segmentedControls, settings) {
      */
     this.init = function() {
         this.iconSet.registerAsSegment(this);
+        var eventId = 'segmentedControl' + this.iconSet.label;
         this.element = $('<div></div>');
         this.element.text(this.iconSet.label);
+        this.element.attr('data-id', eventId);
         this.element.appendTo(this.parent.segmentControlContainer);
-        this.addListeners();
+        this.parent.carousel.registerListener(eventId, yudu_events.callback(this, this.handleClick));
     };
 
     /**
@@ -885,13 +887,6 @@ var CarouselSegmentedControl = function(segmentedControls, settings) {
      */
     this.handleClick = function() {
         this.parent.selectSegment(this);
-    };
-
-    /**
-     * Registers the event handlers for this segment
-     */
-    this.addListeners = function() {
-        this.element.on(yudu_commonSettings.clickAction, yudu_events.callback(this, this.handleClick));
     };
     //endregion
 

--- a/toolbar/style.less
+++ b/toolbar/style.less
@@ -245,3 +245,7 @@
     margin: 2px;
   }
 }
+
+.noPointerEvents {
+  pointer-events: none;
+}

--- a/toolbar/toolbar.html
+++ b/toolbar/toolbar.html
@@ -17,9 +17,9 @@
         </div>
     </div>
     <div id="shareButtons">
-        <div id="email" class="shareOption"><span class="yudu_localisable">sharing.email</span></div>
-        <div id="facebook" class="shareOption"><span class="yudu_localisable">sharing.facebook</span></div>
-        <div id="twitter" class="shareOption"><span class="yudu_localisable">sharing.twitter</span></div>
+        <div id="email" class="shareOption"><span class="yudu_localisable noPointerEvents">sharing.email</span></div>
+        <div id="facebook" class="shareOption"><span class="yudu_localisable noPointerEvents">sharing.facebook</span></div>
+        <div id="twitter" class="shareOption"><span class="yudu_localisable noPointerEvents">sharing.twitter</span></div>
     </div>
 </div>
 

--- a/toolbar/toolbar.js
+++ b/toolbar/toolbar.js
@@ -202,7 +202,7 @@ var createButtonNoIcon = function(id, callback) {
     if (!yudu_commonSettings.isDesktop) {
         button.addClass('touchControl');
     }
-    button.on(yudu_commonSettings.clickAction, callback);
+    buttonCallbacks[id] = callback;
     newButton(id, button);
     button.insertBefore($('#rightControls'));
 };

--- a/toolbar/toolbar.js
+++ b/toolbar/toolbar.js
@@ -1,5 +1,6 @@
 var controls = $('#controls');
 var buttons = {};
+var buttonCallbacks = {};
 var visibleButtons = {
     __yudu_count: 0
 };
@@ -85,6 +86,7 @@ var createBar = function() {
         controls.addClass('touchDevice');
     }
     createButtons();
+    addButtonListener();
 };
 
 var showLogo = function() {
@@ -190,7 +192,7 @@ var createButton = function(id, callback, highResIcons) {
         button.addClass('touchControl');
     }
     button.css('background-image', 'url(' + iconPath + ')');
-    button.on(yudu_commonSettings.clickAction, callback);
+    buttonCallbacks[id] = callback;
     newButton(id, button);
     button.insertBefore($('#rightControls'));
 };
@@ -246,6 +248,30 @@ var getIconFor = function(id, highResIcons) {
     return yudu_toolbarSettings.toolbarIconBasePath
             + (highResIcons ? yudu_toolbarSettings.iconHighResPrefix : '')
             + id + yudu_toolbarSettings.iconFileExtension;
+};
+
+/**
+ * Add a listener for tap events to the toolbar
+ * Defers button check to the event handler, so that one handler manages all buttons
+ */
+var addButtonListener = function() {
+    var controlsManager = yudu_commonFunctions.createHammerJSTapManager(controls[0]);
+    controlsManager.on('tap', handleButtonPress);
+};
+
+/**
+ * Callback for tap events on the toolbar
+ * Checks if a button was pressed, and if so, activates its associated callback
+ * @param event {*} fired by HammerJS, DOM event nested in `event.srcEvent`
+ */
+var handleButtonPress = function(event) {
+    var element = event.target;
+    if (element && element.id) {
+        var callback = buttonCallbacks[element.id];
+        if (typeof callback == 'function') {
+            callback();
+        }
+    }
 };
 
 /**

--- a/toolbar/toolbar.js
+++ b/toolbar/toolbar.js
@@ -411,7 +411,6 @@ var initSharing = function() {
      * @param id {string} of the element on page acting as a button and that will contain the image
      * @param imgPath {string} URL of an image to use for the button
      * @param callback {Function} to call when the button is activated
-     * Note the callback should expect a HammerJS event; the DOM event will be nested in `event.srcEvent`
      */
     var addSharingButton = function(id, imgPath, callback) {
         var button = document.getElementById(id);
@@ -420,33 +419,33 @@ var initSharing = function() {
         icon.src = imgPath;
         button.insertBefore(icon, button.firstChild);
         button.style.display = 'block';
-        sharingCallbacks[id] = callback;
+        sharingCallbacks[id] = sharingCallback(callback);
+    };
+
+    /**
+     * Create a callback for when a sharing button is activated
+     * Wraps a callback in shared code to manage the UI changes
+     * @param buttonCallback {Function} that triggers any unique behaviour assigned to the button
+     * @returns {Function} that expects a HammerJS event, and passes it on
+     */
+    var sharingCallback = function(buttonCallback) {
+        return function(event) {
+            hideSharing();
+            typeof buttonCallback == 'function' && buttonCallback(event);
+            yudu_commonFunctions.hideToolbar();
+        }
     };
 
     if (yudu_toolbarSettings.sharing.emailEnabled) {
-        addSharingButton('email', yudu_toolbarSettings.toolbarIconBasePath + 'email.png', function(event) {
-            event.srcEvent.stopPropagation();
-            hideSharing();
-            yudu_sharingFunctions.shareEmail();
-            yudu_commonFunctions.hideToolbar();
-            return false;
-        });
+        addSharingButton('email', yudu_toolbarSettings.toolbarIconBasePath + 'email.png', yudu_sharingFunctions.shareEmail);
     }
 
     if(yudu_toolbarSettings.sharing.twitter) {
-        addSharingButton('twitter', yudu_sharingSettings.twitterIconPath, function() {
-            hideSharing();
-            yudu_sharingFunctions.shareTwitter();
-            yudu_commonFunctions.hideToolbar();
-        });
+        addSharingButton('twitter', yudu_sharingSettings.twitterIconPath, yudu_sharingFunctions.shareTwitter);
     }
 
     if(yudu_toolbarSettings.sharing.facebook) {
-        addSharingButton('facebook', yudu_sharingSettings.facebookIconPath, function() {
-            hideSharing();
-            yudu_sharingFunctions.shareFacebook();
-            yudu_commonFunctions.hideToolbar();
-        });
+        addSharingButton('facebook', yudu_sharingSettings.facebookIconPath, yudu_sharingFunctions.shareFacebook);
     }
 
     setSharingLeftPosition();


### PR DESCRIPTION
@jrdh @beth-hallowell-yudu 

Makes use of HammerJS2, and switches some event handling to it from native events. Combined with changes in the core, this change should switch the toolbar, information page, sharing popup, sharing dialog, contents popup, and thumbnails segmented control to HammerJS.