### PR TITLE
remove function that tries to load thumbnails on login

### DIFF
--- a/thumbnails/thumbnails.js
+++ b/thumbnails/thumbnails.js
@@ -603,19 +603,10 @@ var Thumbnails = function(settings) {
         this.updateVisibleIcons();
     };
 
-    /**
-     * Event handler (HTML Reader) to respond to a "logged in" event
-     */
-    this.loggedIn = function() {
-        for(var i = 0; i < this.iconsLength(); i++) {
-            this.icons()[i].setImage();
-        }
-    };
-
     // Other listeners for the thumbnails bar
     yudu_events.subscribe(yudu_events.ALL, yudu_events.THUMBNAILS.PAGE_CHANGED, yudu_events.callback(this, this.setPageNumber), false);
     yudu_events.subscribe(yudu_events.ALL, yudu_events.COMMON.TOUCH, yudu_events.callback(this, this.toggle, false, false), false);
-    yudu_events.subscribe(yudu_events.ALL, yudu_events.COMMON.LOGIN_SUCCESS, yudu_events.callback(this, this.loggedIn), false);
+
     //endregion
 };
 


### PR DESCRIPTION
Fixes [this](https://trello.com/c/oa7mhYms/3669-pub-3173-sen-misset-give-access-to-editions-sharing-the-external-auth-id-on-successful-authentication-dummy-auth-id) and [this](https://trello.com/c/isWixFbm/3668-pub-3172-publisher-html-reader-zoom-jumping-back-to-100).
Instead of [this pull request](https://github.com/yudugit/html-reader/pull/356).

@alexandergeeyudu 
