### PR TITLE
Toolbar button Accessibility

### DIFF
--- a/toolbar/style.less
+++ b/toolbar/style.less
@@ -4,23 +4,30 @@
   box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, 0.3);
   height: 34px;
   width: 100%;
-  position: absolute;
+  position: fixed;
   z-index: 2000;
   white-space: nowrap;
 
   .control {
     border: none;
-    background: transparent no-repeat center;
-    background-size: contain;
     outline: none;
+
     width: 24px;
     height: 24px;
     display: inline-block;
 
     margin: 5px 10px;
     padding: 0;
+    text-align: center;
+
 
     &:hover {cursor: pointer;}
+
+    img {
+      vertical-align: middle;
+      max-width: 24px;
+      max-height: 24px;
+    }
   }
 
   .touchControl {

--- a/toolbar/toolbar.js
+++ b/toolbar/toolbar.js
@@ -49,11 +49,11 @@ var handleShoppingCartEvent = function(event) {
     if (event.data.toggleIcon) {
         var highResIcons = yudu_toolbarSettings.shouldUseHighRes;
         var mainIconPath = getIconFor('shoppingCart', highResIcons);
-        if (button.css('background-image').indexOf(mainIconPath.substr(1)) >= 0) {
+        if (button.children('img').attr('src').indexOf(mainIconPath.substr(1)) >= 0) {
             var highlightedIconPath = getIconFor('highlightedShoppingCart', highResIcons);
-            button.css('background-image', 'url(' + highlightedIconPath + ')');
+            button.children('img').attr('src', highlightedIconPath);
         } else {
-            button.css('background-image', 'url(' + mainIconPath + ')');
+            button.children('img').attr('src', mainIconPath);
         }
     }
 

--- a/toolbar/toolbar.js
+++ b/toolbar/toolbar.js
@@ -196,7 +196,7 @@ var createButton = function(id, callback, highResIcons) {
         button.addClass('touchControl');
     }
 
-    buttonCallbacks[id] = callback();
+    buttonCallbacks[id] = callback;
 
     $('<img />')
         .attr('src', iconPath)
@@ -290,7 +290,6 @@ var handleButtonPress = function(event) {
  *  mean the buttons will not be rendered (and hence not visible) on initial calculation
  */
 var positionButtonsForTouch = function() {
-    console.log('here');
     if (visibleButtons.__yudu_count == 0) {
         return;
     }

--- a/toolbar/toolbar.js
+++ b/toolbar/toolbar.js
@@ -203,12 +203,7 @@ var createButton = function(id, callback, highResIcons) {
         .attr('id', id);
 
     var altText = yudu_commonFunctions.getLocalisedStringByCode('toolbar.button.' + id);
-    console.log('altText: ', altText);
-    if (altText) {
-        icon.attr('aria-label', altText);
-    }
-
-    icon.appendTo(button);
+    icon.attr('aria-label', altText.indexOf('toolbar.button.') === 0 ? id : altText).appendTo(button);
 
     newButton(id, button);
     button.insertBefore($('#rightControls'));

--- a/toolbar/toolbar.js
+++ b/toolbar/toolbar.js
@@ -71,7 +71,7 @@ var handleBookmarkUpdateEvent = function(event) {
     var button = buttons['bookmark'];
     var bookmarked = event.data.bookmarkOn;
     var iconPath = getIconFor((bookmarked ? 'bookmarked' : 'bookmark'));
-    button.css('background-image', 'url(' + iconPath + ')');
+    button.children('img').attr('src', iconPath);
 };
 
 var createBar = function() {
@@ -191,12 +191,18 @@ var createButtons = function() {
 
 var createButton = function(id, callback, highResIcons) {
     var iconPath = getIconFor(id, highResIcons);
-    var button = $('<a type="button" class="control" tabindex="-1" id="' + id + '"></a>');
+    var button = $('<a type="button" class="control" id="' + id + '"></a>');
     if (!yudu_commonSettings.isDesktop) {
         button.addClass('touchControl');
     }
-    button.css('background-image', 'url(' + iconPath + ')');
-    buttonCallbacks[id] = callback;
+
+    buttonCallbacks[id] = callback();
+
+    $('<img />')
+        .attr('src', iconPath)
+        .attr('id', id)
+        .appendTo(button);
+
     newButton(id, button);
     button.insertBefore($('#rightControls'));
 };
@@ -284,19 +290,18 @@ var handleButtonPress = function(event) {
  *  mean the buttons will not be rendered (and hence not visible) on initial calculation
  */
 var positionButtonsForTouch = function() {
+    console.log('here');
     if (visibleButtons.__yudu_count == 0) {
         return;
     }
     var gap = controls.width() / visibleButtons.__yudu_count;
-    var offset = false;
     var count = 0;
     // need to iterate over `buttons` to preserve button order
     for (var id in buttons) {
         if (visibleButtons.hasOwnProperty(id)) {
-            if (offset === false) {
-                offset = (gap / 2) - (visibleButtons[id].outerWidth(true) / 2);
-            }
-            visibleButtons[id].css({"left": offset + (gap * count)});
+            var offset = (visibleButtons[id].outerWidth(true) / 2);
+            var position = (gap / 2) + (gap * count) - offset;
+            visibleButtons[id].css({"left": position });
             count++;
         }
     }

--- a/toolbar/toolbar.js
+++ b/toolbar/toolbar.js
@@ -198,10 +198,17 @@ var createButton = function(id, callback, highResIcons) {
 
     buttonCallbacks[id] = callback;
 
-    $('<img />')
+    var icon = $('<img />')
         .attr('src', iconPath)
-        .attr('id', id)
-        .appendTo(button);
+        .attr('id', id);
+
+    var altText = yudu_commonFunctions.getLocalisedStringByCode('toolbar.button.' + id);
+    console.log('altText: ', altText);
+    if (altText) {
+        icon.attr('aria-label', altText);
+    }
+
+    icon.appendTo(button);
 
     newButton(id, button);
     button.insertBefore($('#rightControls'));

--- a/toolbarPhoneview/toolbarPhoneview.js
+++ b/toolbarPhoneview/toolbarPhoneview.js
@@ -23,6 +23,8 @@ var initSharing = function() {
         }
     };
 
+    sharingUI.dropdown.firstPage.attr('tabIndex', '-1');
+
     var sharingCallbacks = {};
 
     /**
@@ -128,6 +130,7 @@ var toggleSharing = function(toggle, show) {
     }
     if (shouldShow) {
         sharingUI.dropdown.container.show();
+        sharingUI.dropdown.firstPage.focus();
     } else {
         sharingUI.dropdown.container.hide();
     }


### PR DESCRIPTION
Updates the structure of the main toolbar buttons to match the Phoneview toolbar, so that they are visible to screen readers, and adds proper labels to improve their accessibility.

@tobiaspowell
[Trello](https://trello.com/c/bocBfLTc/502-html-reader-accessibility)