### PR TITLE
Add support for sharing via LinkedIn

### DIFF
--- a/docs/api/sharing.md
+++ b/docs/api/sharing.md
@@ -12,6 +12,8 @@ Its two components will be available as the following global variables:
     + available only if `yudu_toolbarSettings.sharing.twitter` is `true`
 + `facebookIconPath` – the path of the image used for the Facebook icon in the sharing box
     + available only if `yudu_toolbarSettings.sharing.facebook` is `true`
++ `linkedInIconPath` – the path of the image used for the LinkedIn icon in the sharing box
+    + available only if `yudu_toolbarSettings.sharing.linkedIn` is `true`
 
 ## Sharing Functions
 
@@ -24,3 +26,5 @@ Its two components will be available as the following global variables:
     + available only if `yudu_toolbarSettings.sharing.twitter` is `true`
 + `shareFacebook` – call when the "share on Facebook" button is clicked
     + available only if `yudu_toolbarSettings.sharing.facebook` is `true`
++ `shareLinkedIn` – call when the "share on LinkedIn" button is clicked
+    + available only if `yudu_toolbarSettings.sharing.linkedIn` is `true`

--- a/docs/overrides/strings.md
+++ b/docs/overrides/strings.md
@@ -15,6 +15,7 @@ The current default English values are as follows (in JSON format):
     "sharing.email": "Email",
     "sharing.facebook": "Facebook",
     "sharing.twitter": "Twitter",
+    "sharing.linkedIn": "LinkedIn",
     "sharing.fromAddress": "From",
     "sharing.toAddress": "To",
     "sharing.fromAddressPlaceholder": "me@example.com",

--- a/toolbar/toolbar.html
+++ b/toolbar/toolbar.html
@@ -20,6 +20,7 @@
         <div id="email" class="shareOption"><span class="yudu_localisable noPointerEvents">sharing.email</span></div>
         <div id="facebook" class="shareOption"><span class="yudu_localisable noPointerEvents">sharing.facebook</span></div>
         <div id="twitter" class="shareOption"><span class="yudu_localisable noPointerEvents">sharing.twitter</span></div>
+        <div id="linkedIn" class="shareOption"><span class="yudu_localisable noPointerEvents">sharing.linkedIn</span></div>
     </div>
 </div>
 

--- a/toolbar/toolbar.js
+++ b/toolbar/toolbar.js
@@ -134,7 +134,7 @@ var createButtons = function() {
     if (yudu_contentsSettings.contentsData && yudu_contentsSettings.contentsData.length > 0) {
         createButton('contents', toggleContentsAction, highResIcons);
     }
-    if (yudu_toolbarSettings.sharing.emailEnabled || yudu_toolbarSettings.sharing.twitter || yudu_toolbarSettings.sharing.facebook) {
+    if (yudu_toolbarSettings.sharing.emailEnabled || yudu_toolbarSettings.sharing.twitter || yudu_toolbarSettings.sharing.facebook || yudu_toolbarSettings.sharing.facebook) {
         createButton('share', toggleShareAction, highResIcons);
     }
     if (yudu_toolbarSettings.hasDownloadablePdfAndIsNotApp) {
@@ -401,7 +401,7 @@ var initSharing = function() {
         return false;
     });
 
-    if (yudu_toolbarSettings.sharing.emailEnabled || yudu_toolbarSettings.sharing.twitter || yudu_toolbarSettings.sharing.facebook) {
+    if (yudu_toolbarSettings.sharing.emailEnabled || yudu_toolbarSettings.sharing.twitter || yudu_toolbarSettings.sharing.facebook || yudu_toolbarSettings.sharing.linkedIn) {
         sharingCallbacks.currentPage = function() {
             toggleSharingPage(true);
         };
@@ -450,6 +450,10 @@ var initSharing = function() {
 
     if(yudu_toolbarSettings.sharing.facebook) {
         addSharingButton('facebook', yudu_sharingSettings.facebookIconPath, yudu_sharingFunctions.shareFacebook);
+    }
+
+    if(yudu_toolbarSettings.sharing.linkedIn) {
+        addSharingButton('linkedIn', yudu_sharingSettings.linkedInIconPath, yudu_sharingFunctions.shareLinkedIn);
     }
 
     setSharingLeftPosition();

--- a/toolbarPhoneview/toolbarPhoneview.html
+++ b/toolbarPhoneview/toolbarPhoneview.html
@@ -11,5 +11,6 @@
         <div id="email" class="shareOption"><span class="yudu_localisable noPointerEvents">sharing.email</span></div>
         <div id="facebook" class="shareOption"><span class="yudu_localisable noPointerEvents">sharing.facebook</span></div>
         <div id="twitter" class="shareOption"><span class="yudu_localisable noPointerEvents">sharing.twitter</span></div>
+        <div id="linkedIn" class="shareOption"><span class="yudu_localisable noPointerEvents">sharing.linkedIn</span></div>
     </div>
 </div>

--- a/toolbarPhoneview/toolbarPhoneview.js
+++ b/toolbarPhoneview/toolbarPhoneview.js
@@ -44,7 +44,7 @@ var initSharing = function() {
         return false;
     });
 
-    if (yudu_toolbarSettings.sharing.emailEnabled || yudu_toolbarSettings.sharing.twitter || yudu_toolbarSettings.sharing.facebook) {
+    if (yudu_toolbarSettings.sharing.emailEnabled || yudu_toolbarSettings.sharing.twitter || yudu_toolbarSettings.sharing.facebook || yudu_toolbarSettings.sharing.linkedIn) {
         sharingCallbacks.currentPage = function() {
             toggleSharingPage(true);
         };
@@ -93,6 +93,10 @@ var initSharing = function() {
 
     if(yudu_toolbarSettings.sharing.facebook) {
         addSharingButton('facebook', yudu_sharingSettings.facebookIconPath, yudu_sharingFunctions.shareFacebook);
+    }
+
+    if(yudu_toolbarSettings.sharing.linkedIn) {
+        addSharingButton('linkedIn', yudu_sharingSettings.linkedInIconPath, yudu_sharingFunctions.shareLinkedIn);
     }
 
     setSharingLeftPosition();


### PR DESCRIPTION
Adds LinkedIn alongside facebook and twitter as supported platforms

[Trello](https://trello.com/c/UpqQOpha/234-extend-html-fixed-view-and-phone-view-sharing-to-support-linkedin)

@farizbenchaoui-yudu 