### PR TITLE
Remove obsolete test for articlesAvailable

### DIFF
--- a/assets/noAccess.html
+++ b/assets/noAccess.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Please log in</title>
+    <style>
+        html, body, h1 {
+            height: 100%;
+        }
+
+        h1 {
+            display: -webkit-flexbox;
+            display: -ms-flexbox;
+            display: -webkit-flex;
+            display: flex;
+            -webkit-flex-align: center;
+            -ms-flex-align: center;
+            -webkit-align-items: center;
+            align-items: center;
+            justify-content: center;
+            font-size: 28px;
+            font-family: Verdana, sans-serif;
+        }
+    </style>
+</head>
+<body>
+<h1>You must login to view this article</h1>
+</body>
+</html>

--- a/docs/api/toolbar.md
+++ b/docs/api/toolbar.md
@@ -59,12 +59,8 @@ Its two components will be available as the following global variables:
     + available only when `yudu_toolbarSettings.bookmarksEnabled` is `true`
 + `notesClicked` – call when the `notes` button is clicked
     + available only when `yudu_toolbarSettings.notesEnabled` is `true`
-+ `articlesAvailable` - call to check if articles data is available
-    + for a protected edition, may start returning `false` but later return `true` if a user has logged in successfully
-    + may subscribe to the `COMMON.LOGIN_APPROVED` event for hints of changes to this result
-    + once articles data is available, it should not become "unavailable" during the lifetime of the reader
 + `openPhoneView` - call when the `phoneview` button is clicked
-    + will do nothing unless `yudu_toolbarSettings.hasArticles` is `true` and `articlesAvailable` returns true
+    + will do nothing unless `yudu_toolbarSettings.hasArticles` is `true`
 + `setAutoHide(enable)` – call when a button triggering a togglable is clicked to stop the toolbar from hiding when the togglable is shown (`enable = false`) or to re-enable auto hiding after a certain period of time when the togglable is hidden (`enable = true`)
     + a togglable is a feature represented by a box whose visibility is toggled by a toolbar button and which requires the toolbar to remain visible for the duration for which it's shown (e.g. sharing or contents)
 + `editionLaunchableHtmlClicked` - call when the `editionLaunchableHtml` button is clicked

--- a/toolbar/toolbar.js
+++ b/toolbar/toolbar.js
@@ -21,7 +21,6 @@ var registerForYuduEvents = function() {
     yudu_events.subscribe(yudu_events.ALL, yudu_events.TOOLBAR.UPDATE_BOOKMARK_BUTTON, handleBookmarkUpdateEvent, false);
     yudu_events.subscribe(yudu_events.ALL, yudu_events.COMMON.RESIZE, onResize, false);
     yudu_events.subscribe(yudu_events.ALL, yudu_events.COMMON.TOUCH, hideTogglables, false);
-    yudu_events.subscribe(yudu_events.ALL, yudu_events.COMMON.LOGIN_APPROVED, onLoginApproved, false);
     if (window.yudu_searchFunctions) {
         searchSetup();
     } else {
@@ -171,11 +170,6 @@ var createButtons = function() {
         createButton('userPreferences', toggleUserPreferencesAction, highResIcons);
     }
 
-    // if not logged into a protected edition, phoneview should not be available yet
-    if (!yudu_toolbarFunctions.articlesAvailable()) {
-        hideButton('phoneview');
-        // note: the button is shown when the reader emits a `LOGIN_APPROVED` event - see the `onLoginApproved` function below
-    }
     //the fitPage button is the toggled version of the fitWidth so hide it by default
     hideButton('fitPage');
 
@@ -825,16 +819,6 @@ var onResize = function () {
     }
     setTogglableLeftPosition();
     positionSearchResults();
-};
-
-var onLoginApproved = function() {
-    if (yudu_toolbarFunctions.articlesAvailable()) {
-        showButton('phoneview');
-        if (!yudu_commonSettings.isDesktop) {
-            positionButtonsForTouch();
-        }
-        yudu_events.unsubscribe(yudu_events.ALL, yudu_events.COMMON.LOGIN_APPROVED, onLoginApproved, false);
-    }
 };
 
 var setTogglableLeftPosition = function() {


### PR DESCRIPTION
@peter-cox The PV auth changes mean the articlesAvailable test is obsolete and no longer called.

**This mustn't be merged to master until the phoneview-drm-wip branches on html-reader and Publisher have also been merged!**