### PR TITLE
Emit Event to help re-open the toolbar after closing the thumbnail slider without changing page

### DIFF
--- a/thumbnails/thumbnails.js
+++ b/thumbnails/thumbnails.js
@@ -1106,6 +1106,7 @@ var CarouselScroller = function(carousel, settings) {
             this.carousel.isSpringing = false;
             var pageNumber = parseInt($.data(event.target, "page"));
             yudu_commonFunctions.goToPage(pageNumber);
+            yudu_events.emit(yudu_events.ALL, yudu_events.THUMBNAILS.HIDE_THUMBNAILS_PAGE_NOT_CHANGED);
             this.carousel.toggle(false, false);
         }
     };

--- a/thumbnails/thumbnails.js
+++ b/thumbnails/thumbnails.js
@@ -376,6 +376,7 @@ var Thumbnails = function(settings) {
             yudu_commonFunctions.hideToolbar();
             this.carouselContainerElement.show();
         } else {
+            yudu_events.emit(yudu_events.ALL, yudu_events.THUMBNAILS.HIDE_THUMBNAILS_PAGE_NOT_CHANGED);
             this.carouselContainerElement.hide();
         }
         return this.isVisible;
@@ -1106,7 +1107,6 @@ var CarouselScroller = function(carousel, settings) {
             this.carousel.isSpringing = false;
             var pageNumber = parseInt($.data(event.target, "page"));
             yudu_commonFunctions.goToPage(pageNumber);
-            yudu_events.emit(yudu_events.ALL, yudu_events.THUMBNAILS.HIDE_THUMBNAILS_PAGE_NOT_CHANGED);
             this.carousel.toggle(false, false);
         }
     };


### PR DESCRIPTION
@tobiaspowell 
[Trello](https://trello.com/c/dBo11HoL/630-html-editions-in-android-app-fixed-bottom-toolbar-edition-side-setting-interferes-with-toc-thumbnail-scrollbar-when-enabled-mean)

Links with [html-reader PR #449](https://github.com/yudugit/html-reader/pull/449)