### PR TITLE
Include noAccess.html file in branding pack build process

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,7 @@ task copyBrandingPack(type: Copy, dependsOn: [cleanBuild, build]) {
     include 'phoneview/'
     include 'customStringsPack.json/'
     include 'assets/audio/'
+    include 'assets/noAccess.html'
     include 'logo.png'
     include 'placeholder.png'
     // exclude all sourcemap files


### PR DESCRIPTION
The file isn't included in the script that builds the release. When viewing a DRM-protected edition in phoneview, the pages display a generic 'Access Denied' S3 error rather than the intended 'noAccess.html' (before logging in) because the file is missing from the preview/publish folder.

@tobiaspowell 