### PR TITLE
Fix download pdf dropdown buttons sometimes not showing

### DIFF
--- a/toolbar/style.less
+++ b/toolbar/style.less
@@ -231,7 +231,6 @@
       height: 40px;
       width: -webkit-calc(~"100% - 22px");
       width: calc(~"100% - 22px");
-      display: none;
 
       span {
         position: absolute;

--- a/toolbar/toolbar.js
+++ b/toolbar/toolbar.js
@@ -654,8 +654,9 @@ var initDownloadPdfMenu = function() {
 
     Object.values(downloadPdfOptions).forEach(function(option) {
         if (option.enabled) {
-            downloadPdfMenuUI.dropdown[option.name].show();
             downloadPdfMenuCallbacks[option.name] = downloadPdfMenuCallback(option.menuCallback);
+        } else {
+            downloadPdfMenuUI.dropdown[option.name].hide();
         }
     });
 


### PR DESCRIPTION
The first part of [this Trello ticket](https://trello.com/c/wO5tWqYl)

show() was sometimes not working here, but hide() looks like it works consistently.

Setting display directly to `block` instead of using show() also appears to work, but this seems like a better way of doing it.

@ruxandra-codreanu-yudu 